### PR TITLE
Quantum repetition and bacon shor files fixed

### DIFF
--- a/codes/quantum/qubits/quantum_repetition.yml
+++ b/codes/quantum/qubits/quantum_repetition.yml
@@ -28,7 +28,7 @@ protection: 'Bit-flip code detects bit-flip errors \(X\) on \(\left\lfloor (n-1)
 
 realizations:
   - 'NMR: 3-qubit phase-flip code \cite{arxiv:quant-ph/9802018,arXiv:1108.4842}, with up to two rounds of error correction in liquid-state NMR \cite{arXiv:1109.4821}.'
-  - 'Superconducting circuits: 3-qubit phase-flip and bit-flip code by Schoelkopf group \cite{arXiv:1109.4948}, IBM 15-qubit device \cite{arXiv:1709.00990}, Google experiment performing up to 8 error-correction cycles on 5 and 9 qubits \cite{arXiv:1411.7403}, and Google Quantum AI Sycamore utilizing from 5 to 21 qubits \cite{arXiv:2102.06132}. Continuous error correction protocols have been implemented on a 3-qubit superconducting circuit device \cite{arxiv:2107.11398}.'
+  - 'Superconducting circuits: 3-qubit phase-flip and bit-flip code by Schoelkopf group \cite{arXiv:1109.4948}, another 3-qubit bit-flip code \cite{arXiv:1411.5542}, 3-qubit phase-flip code up to 3 cycles of error correction \cite{arXiv:1508.01388}, IBM 15-qubit device \cite{arXiv:1709.00990}, IBM Rochester device using 43-qubit code \cite{arXiv:2004.11037}, Google Quantum AI Sycamore performing up to 8 error-correction cycles on 5 and 9 qubits \cite{arXiv:1411.7403}, and Google Quantum AI Sycamore utilizing from 5 to 21 qubits \cite{arXiv:2102.06132}. Continuous error correction protocols have been implemented on a 3-qubit superconducting circuit device \cite{arxiv:2107.11398}.'
   - 'Semiconductor spin-qubit devices: 3-qubit devices at RIKEN \cite{arXiv:2201.08581} and Delft \cite{arXiv:2202.11530}.'
   - 'Nitrogen-vacancy centers in diamond: 3-qubit device \cite{doi:10.1038/s42005-022-00875-6}.'
   - 'See Table S6 in Ref. \cite{arXiv:2102.06132} for a history of earlier implementations.'

--- a/codes/quantum/qubits/subsystem/bacon_shor.yml
+++ b/codes/quantum/qubits/subsystem/bacon_shor.yml
@@ -43,7 +43,7 @@ features:
 
 realizations:
   - 'Trapped-ion qubits: state preparation, logical measurement, and stabilizer measurement for nine-qubit Bacon-Shor code demonstrated on a 13-qubit device by M. Cetina and C. Monroe groups \cite{arxiv:2009.11482}.'
-
+  - 'Photons: quantum teleportation of information implemented on maximally entangled pair of one physical and one logical qubit with fidelity rate of up to 78.6\% \cite{arXiv:2009.06242}.'
 relations:
   parents:
     - code_id: bravyi_bacon_shor


### PR DESCRIPTION
Sorry about messing them up and having redundant arXiv references.  They should be fixed now.