### PR TITLE
Some more thresholds for triangular and hexagonal color codes

### DIFF
--- a/codes/quantum/qubits/topological/color.yml
+++ b/codes/quantum/qubits/topological/color.yml
@@ -37,15 +37,21 @@ features:
     - 'Steane''s ancilla-coupled measurement method \cite{arXiv:1407.5103}'
 
   code_capacity_threshold:
+    - '\(12.6\%\) threshold for triangular color code with the restriction decoder \cite{arXiv:1911.00355}.'
+    - '\(12.6\%\) threshold for triangular color code with the projection decoder (\cite{arXiv:1308.6207}) \cite{arXiv:1802.08680}'
+    - '\(8.7\%\) threshold for phase errors for the hexagonal color code with the projection decoder \cite{arXiv:1308.6207}'
     - '\(\geq 6\%\) threshold with rescaling-based decoder \cite{arXiv:2112.09584}.'
+    
 
   threshold:
     - '\(\geq 6.25\%\) threshold for 2D color codes with error-free syndrome extraction, and \(0.1\%\) with faulty syndrome extraction \cite{arXiv:0907.1708}.'
     - '\(0.46\%\) for 3D codes with clustering decoder \cite{arXiv:1708.07131}.'
     - '\(1.9\%\) for 1D string-like logical operators and \(27.6\%\) for 2D sheet-like operators for 3D codes with noise models using optimal decoding and perfect measurements \cite{arXiv:1708.07131}.'
     - '\(0.31\%\) noise threshold error rate for gauge code using clustering decoder \cite{arXiv:1503.08217}.'
-    - '\(0.143\%\) with depolarising circuit-level noise using perfect-matching decoder \cite{arXiv:1407.5103}.'
+    - '\(0.2\%\) with depolarizing circuit-level noise using two flag-qubits per stabilizer generator and the restriction decoder \cite{arXiv:1911.00355}.'
+    - '\(0.143\%\) with depolarizing circuit-level noise using perfect-matching decoder \cite{arXiv:1407.5103}.'
     - '\(>0\%\) threshold with sweep decoder \cite{doi:10.7907/059V-MG69}.'
+    
 
 #realizations:
 
@@ -70,6 +76,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: balopat
+      date: '2023-01-11'
     - user_id: VictorVAlbert
       date: '2022-01-05'
     - user_id: XiaozhenFu

--- a/users/users_db.yml
+++ b/users/users_db.yml
@@ -316,6 +316,11 @@
 - user_id: GraceSommers
   name: 'Grace Sommers'
 
+- user_id: balopat
+  name: 'Balint Pato'
+  gscholaruser: 'mnNvWjkAAAAJ'
+  githubusername: balopat
+  pageurl: 'https://refactorium.com/'
 
 #
 # Core members -- add 'zooteam: core' and 'zoorole: <role>' to each entry.


### PR DESCRIPTION
## Modified Codes:

**Color code**:
- adding thresholds for triangular and hexagonal color codes based on 
  - Chamberland et al. arXiv:1911.00355
  - Delfosse arXiv:1308.6207 

## Checklist:

I remembered to:

- [x] Include relevant citations I could think of (with `\cite{...}`)

- [x] Create links to the other referenced codes (with
      `\hyperref[code:...]{...}`)

- [x] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

