### PR TITLE
Update surface code re: planar variants

### DIFF
--- a/codes/quantum/qubits/topological/surface/surface/surface.yml
+++ b/codes/quantum/qubits/topological/surface/surface/surface.yml
@@ -52,8 +52,8 @@ description: |
 
 protection: |
   Toric code on an \(L\times L\) torus is a \([[2L^2,2,L]]\) CSS code, and there
-  exists a planar code with \([[L^2,1,L]]\) \cite{arxiv:1111.4022}. More
-  generally, the code distance is related to the homology of the cellulation
+  exists a planar \(2L^2-2d+1\) CSS code \cite{arxiv:quant-ph/9810055}\cite{arxiv:quant-ph/9811052}. 
+  More generally, the code distance is related to the homology of the cellulation
   \cite{arXiv:quant-ph/0110143}.
 
   Coherent physical errors are expected to become incoherent logical errors after MWPM decoding; see corroborating numerical studies performed via the Majorana mapping \cite{arxiv:1710.02270} as well as analytical bounds \cite{arxiv:1912.04319}.
@@ -166,6 +166,9 @@ relations:
         realize \(\mathbb{Z}_2\) topological order, a topological phase of
         matter that also exists in \(\mathbb{Z}_2\) lattice gauge theory
         \cite{doi:10.1063/1.1665530}. Codewords correspond to ground state of the code Hamiltonian, and error operators correspond to spontaneous creation and annihilation of pairs of charges or vortices.
+  child:
+    - code_is: rotated_surface_code
+      detail: 'A planar code with higher rate (for the same distance) can be obtained by rotating the lattice \(45^{\circ}\) and modifying the boundaries.'
   cousins:
     - code_id: hypergraph_product
       detail: 'Planar (toric) code can be obtained from hypergraph product of two repetition (cyclic) codes (\cite{arxiv:1202.0928}, Ex. 6).'
@@ -180,6 +183,8 @@ relations:
 # Begin Entry Meta Information
 _meta:
   changelog:
+    - user_id: marcusps # github
+      date: '2023-03-15'
     - user_id: VictorVAlbert
       date: '2022-09-20'
     - user_id: VictorVAlbert

--- a/codes/quantum/qubits/topological/surface/surface/surface.yml
+++ b/codes/quantum/qubits/topological/surface/surface/surface.yml
@@ -166,7 +166,7 @@ relations:
         realize \(\mathbb{Z}_2\) topological order, a topological phase of
         matter that also exists in \(\mathbb{Z}_2\) lattice gauge theory
         \cite{doi:10.1063/1.1665530}. Codewords correspond to ground state of the code Hamiltonian, and error operators correspond to spontaneous creation and annihilation of pairs of charges or vortices.
-  child:
+  children:
     - code_is: rotated_surface_code
       detail: 'A planar code with higher rate (for the same distance) can be obtained by rotating the lattice \(45^{\circ}\) and modifying the boundaries.'
   cousins:

--- a/codes/quantum/qubits/topological/surface/surface/surface.yml
+++ b/codes/quantum/qubits/topological/surface/surface/surface.yml
@@ -180,7 +180,7 @@ relations:
 # Begin Entry Meta Information
 _meta:
   changelog:
-    - user_id: marcusps # github
+    - user_id: MarcusPS
       date: '2023-03-15'
     - user_id: VictorVAlbert
       date: '2022-09-20'

--- a/codes/quantum/qubits/topological/surface/surface/surface.yml
+++ b/codes/quantum/qubits/topological/surface/surface/surface.yml
@@ -166,9 +166,6 @@ relations:
         realize \(\mathbb{Z}_2\) topological order, a topological phase of
         matter that also exists in \(\mathbb{Z}_2\) lattice gauge theory
         \cite{doi:10.1063/1.1665530}. Codewords correspond to ground state of the code Hamiltonian, and error operators correspond to spontaneous creation and annihilation of pairs of charges or vortices.
-  children:
-    - code_is: rotated_surface_code
-      detail: 'A planar code with higher rate (for the same distance) can be obtained by rotating the lattice \(45^{\circ}\) and modifying the boundaries.'
   cousins:
     - code_id: hypergraph_product
       detail: 'Planar (toric) code can be obtained from hypergraph product of two repetition (cyclic) codes (\cite{arxiv:1202.0928}, Ex. 6).'

--- a/users/users_db.yml
+++ b/users/users_db.yml
@@ -343,6 +343,12 @@
   gscholaruser: 'mnNvWjkAAAAJ'
   githubusername: balopat
   pageurl: 'https://refactorium.com/'
+  
+- user_id: MarcusPS
+  name: 'Marcus P da Silva'
+  gscholaruser: 'qsKgI6AAAAAJ'
+  githubusername: marcusps
+  pageurl: 'https://marcusps.github.io/'
 
 #
 # Core members -- add 'zooteam: core' and 'zoorole: <role>' to each entry.


### PR DESCRIPTION
Fixed code parameters and references, added relation to "rotated surface code".


## Modified Codes:

**Kitaev surface code**:
- added references to planar variant publications (Freedman & Meyer, Bravyi & Kitaev)
- fixed code parameters for planar variant

## Checklist:

I remembered to:

- [X] Include relevant citations I could think of (with `\cite{...}`)

- [X] Create links to the other referenced codes (with
      `\hyperref[code:...]{...}`)

- [X] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

