### PR TITLE
Fixed and added references in surface and rotated_surface codes.

### DIFF
--- a/codes/quantum/qubits/topological/surface/rotated_surface.yml
+++ b/codes/quantum/qubits/topological/surface/rotated_surface.yml
@@ -18,12 +18,14 @@ features:
   decoders:
     - 'Local neural-network using 3D convolutions, combined with a separate global decoder \cite{arxiv:2208.01178}.'
   fault_tolerance:
-    - 'A particular choice of CNOT gates during syndrome extraction is required to be fault-tolerant to syndrome qubit errors \cite{arXiv:1404.3747}.'
+    - 'A particular choice of CNOT gates during syndrome extraction is required to be fault-tolerant to syndrome qubit errors \cite{arXiv:quant-ph/0110143}\cite{arXiv:1208.0928}\cite{arXiv:1404.3747}.'
 
 relations:
   parents:
     - code_id: clifford-deformed_surface
       detail: 'Rotated surface codes can be obtained from surface codes via a constant-depth Clifford circuit.'
+    - code_id: surface
+      detail: 'Rotated surface codes can be obtained using the same procedure as for the original surface codes but considering slightly different combinatorial surfaces \cite{arXiv:quant-ph/0703272} \cite{arXiv:1606.07116} than those considered in the original proposal.'
     - code_id: quantum_tanner
       detail: 'Specializing the quantum Tanner construction to the surface code yields the rotated surface code \cite{manual:{Nikolas P. Breuckmann, private communication, 2022},manual:{Anthony Leverrier, \href{https://github.com/errorcorrectionzoo/eczoo_data/files/9210173/rotated.pdf}{Mapping the toric code to the rotated toric code}, 2022.}}.'
     - code_id: hierarchical
@@ -39,5 +41,7 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: MarcusPS
+      date: '2023-03-20'
     - user_id: VictorVAlbert
       date: '2022-07-30'

--- a/codes/quantum/qubits/topological/surface/surface/surface.yml
+++ b/codes/quantum/qubits/topological/surface/surface/surface.yml
@@ -52,7 +52,7 @@ description: |
 
 protection: |
   Toric code on an \(L\times L\) torus is a \([[2L^2,2,L]]\) CSS code, and there
-  exists a planar code, the \hyperref[rotated_surface]{rotated surface code}, with
+  exists a planar code, the \hyperref[code:rotated_surface]{rotated surface code}, with
   \([[L^2,1,L]]\) \cite{arXiv:quant-ph/0703272}. More generally, the code distance
   is related to the homology of the cellulation \cite{arXiv:quant-ph/0110143}
   \cite{arXiv:1606.07116}.

--- a/codes/quantum/qubits/topological/surface/surface/surface.yml
+++ b/codes/quantum/qubits/topological/surface/surface/surface.yml
@@ -19,7 +19,7 @@ description: |
   cellulation). \textit{Toric code} often either refers to the construction on
   the two-dimensional torus or is an alternative name for the general
   construction. The construction on surfaces with boundaries is often called the
-  \textit{planar code} \cite{arXiv:quant-ph/9811052}.
+  \textit{planar code} \cite{arXiv:quant-ph/9810055} \cite{arXiv:quant-ph/9811052}.
 
   The original construction can be naturally extended to arbitrary \(D\)-dimensional
   manifolds
@@ -52,11 +52,12 @@ description: |
 
 protection: |
   Toric code on an \(L\times L\) torus is a \([[2L^2,2,L]]\) CSS code, and there
-  exists a planar code with \([[L^2,1,L]]\) \cite{arxiv:1111.4022}. More
-  generally, the code distance is related to the homology of the cellulation
-  \cite{arXiv:quant-ph/0110143}.
+  exists a planar code, the \hyperref[rotated_surface]{rotated surface code}, with
+  \([[L^2,1,L]]\) \cite{arXiv:quant-ph/0703272}. More generally, the code distance
+  is related to the homology of the cellulation \cite{arXiv:quant-ph/0110143}
+  \cite{arXiv:1606.07116}.
 
-  Coherent physical errors are expected to become incoherent logical errors after MWPM decoding; see corroborating numerical studies performed via the Majorana mapping \cite{arxiv:1710.02270} as well as analytical bounds \cite{arxiv:1912.04319}.
+  Coherent physical errors are expected to become incoherent logical errors under syndrome measurement; see corroborating numerical studies performed via the Majorana mapping \cite{arxiv:1710.02270} as well as analytical bounds \cite{arxiv:1912.04319}.
 
 features:
   rate: |
@@ -180,6 +181,8 @@ relations:
 # Begin Entry Meta Information
 _meta:
   changelog:
+    - user_id: MarcusPS
+      date: '2023-03-20'
     - user_id: VictorVAlbert
       date: '2022-09-20'
     - user_id: VictorVAlbert

--- a/codes/quantum/qubits/topological/surface/surface/surface.yml
+++ b/codes/quantum/qubits/topological/surface/surface/surface.yml
@@ -19,7 +19,8 @@ description: |
   cellulation). \textit{Toric code} often either refers to the construction on
   the two-dimensional torus or is an alternative name for the general
   construction. The construction on surfaces with boundaries is often called the
-  \textit{planar code} \cite{arXiv:quant-ph/9810055} \cite{arXiv:quant-ph/9811052}.
+  \textit{planar code} \cite{arXiv:quant-ph/9810055} \cite{arXiv:quant-ph/9811052}
+  \cite{arXiv:1606.07116}.
 
   The original construction can be naturally extended to arbitrary \(D\)-dimensional
   manifolds

--- a/users/users_db.yml
+++ b/users/users_db.yml
@@ -344,6 +344,11 @@
   githubusername: balopat
   pageurl: 'https://refactorium.com/'
 
+- user_id: MarcusPS
+  name: 'Marcus P da Silva'
+  githubusername: marcusps
+  gscholaruser: 'qsKgI6AAAAAJ'
+
 #
 # Core members -- add 'zooteam: core' and 'zoorole: <role>' to each entry.
 #


### PR DESCRIPTION

## Modified Codes:

**surface code**:
- expanded reference for planar construction
- clarified connection to rotated surface code, with citations and hyperref
- clarified that coherence errors become incoherent because of syndrome measurement, not decoding or a particular decoding algorithm

**rotated surface code**:
- expanded references for fault-tolerant syndrome extraction
- added surface code as parent with references that explain the connection

## Checklist:

I remembered to:

- [X] Include relevant citations I could think of (with `\cite{...}`)

- [X] Create links to the other referenced codes (with
      `\hyperref[code:...]{...}`)

- [X] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

