### PR TITLE
Tiny typo in [[15,1,3]] code

### DIFF
--- a/codes/quantum/qubits/small_distance/small/stab_15_1_3.yml
+++ b/codes/quantum/qubits/small_distance/small/stab_15_1_3.yml
@@ -20,7 +20,7 @@ description: |
 features:
   magic_scaling_exponent: 'Magic-state distillation scaling exponent \( \gamma= \log_d (n/k)\approx 2.46\) \cite{arXiv:1703.07847}.'
 
-  transversal_gates: 'This code is the smallest qubit stabilizer code with a transversal gate outside of the Clifford group \cite{arxiv:2210.14066}. A transversal logical \(T^\dagger\) is implemented by applying a \(T\) gate on every qubit \cite{arXiv:quant-ph/9610011,arXiv:1403.2734,arXiv:1612.07330}. A subsystem version yields a transversal \(CCZ\) gate \cite{arxiv:1304.3709}. The code fails to have a transversal Hadamard gate; otherwise, it would vioalate the Eastin-Knill theorem.'
+  transversal_gates: 'This code is the smallest qubit stabilizer code with a transversal gate outside of the Clifford group \cite{arxiv:2210.14066}. A transversal logical \(T^\dagger\) is implemented by applying a \(T\) gate on every qubit \cite{arXiv:quant-ph/9610011,arXiv:1403.2734,arXiv:1612.07330}. A subsystem version yields a transversal \(CCZ\) gate \cite{arxiv:1304.3709}. The code fails to have a transversal Hadamard gate; otherwise, it would violate the Eastin-Knill theorem.'
 
   general_gates:
     - 'Code is often used in magic-state distillation protocols because of its transversal \(T\) gate \cite{arXiv:quant-ph/0403025}.'
@@ -46,6 +46,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+  - user_id: balopat
+      date: '2023-03-30'
     - user_id: VictorVAlbert
       date: '2021-12-09'
     - user_id: QingfengKeeWang


### PR DESCRIPTION
[Please provide a brief description of your suggested changes here. If you are
simply providing new codes / modifying existing ones, simply describe your
changes below. Don't forget to remove this text.]

## Modified Codes:

**[[15,1,3]] code**:
- fixed small typo

## Checklist:

I remembered to:

- [x] Include relevant citations I could think of (with `\cite{...}`)

- [x] Create links to the other referenced codes (with
      `\hyperref[code:...]{...}`)

- [x] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

