### PR TITLE
Update qubit_css.yml: Fix triply even defn

### DIFF
--- a/codes/quantum/qubits/stabilizer/qubit_css.yml
+++ b/codes/quantum/qubits/stabilizer/qubit_css.yml
@@ -88,7 +88,7 @@ features:
     - 'Clusterization, i.e., measurement of a particular cluster state \cite{arxiv:1607.02579}.'
   transversal_gates: 'All CSS codes admit transversal Pauli and CNOT gates \cite{arXiv:quant-ph/9605011}.
   Self-dual CSS codes admit a transversal Hadamard, completing the Clifford group.
-  A CSS code is \textit{doubly-even} (\textit{triply-even}) if all \(X\)-type stabilizer generators have weight divisible by two (three); such codes yield a transversal \(S\) (\(T\)) gate \cite{arxiv:1509.03239}.'
+  A CSS code is \textit{doubly-even} (\textit{triply-even}) if all \(X\)-type stabilizer generators have weight divisible by four (eight); such codes yield a transversal \(S\) (\(T\)) gate \cite{arxiv:1509.03239}.'
   general_gates:
     - 'LDPC CSS code symmetries called \(XZ\)-dualities allow for fold-transversal gates, i.e., transversal gates followed by qubit permutations \cite{arxiv:2202.06647}.'
     - 'Generalized lattice surgery \cite{arxiv:2301.13738}.'
@@ -141,6 +141,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: ChrisPattison
+      date: '2023-08-12'
     - user_id: balopat
       date: '2023-02-28'
     - user_id: balopat


### PR DESCRIPTION
Modify the definition of triply even code to match page 5 of https://arxiv.org/abs/1509.03239

(Disclaimer: I've only just recently looked into this and noticed the apparent definition discrepancy, so someone please double check this) 