### PR TITLE
[partial] Attempt to add encoding circuits to [[5,1,3]] page

### DIFF
--- a/codes/quantum/qubits/small_distance/small/stab_5_1_3.yml
+++ b/codes/quantum/qubits/small_distance/small/stab_5_1_3.yml
@@ -29,8 +29,83 @@ protection: 'Smallest stabilizer code that protects against a single error on an
 
 features:
   encoders:
-    - 'Four CCZ, four Hadamard, and one \(Z\) gate (\cite{doi:10.1201/9781420012293}, Fig. 10.16).'
-    - 'Four CNOT and five CPHASE gates \cite{arxiv:1509.01239}.'
+    - '4 CCZ, four Hadamard, and one \(Z\) gate (\cite{doi:10.1201/9781420012293}, Fig. 10.16).'
+    - '9 symmetrical two-qubit gates: \cite{arxiv:1509.01239}.
+        stim circuit: stim.Circuit(""" 
+            # Stabilizer Flows:
+            # X____ -> XXXXX
+            # Z____ -> ZZZZZ
+            # _____ -> XZZX_
+            # _____ -> _XZZX
+            # _____ -> X_XZZ
+            # _____ -> ZX_XZ
+
+            R 1 2 3 4
+            
+            Z 0
+            H 1 2 3 4
+        
+            CX 1 0 2 0 3 0 4 0
+            CZ 0 1 1 2 2 3 3 4 4 0
+        """),
+        
+        text diagram:
+            q0: ---Z-X-X-X-X-@-------@-
+                     | | | | |       |
+            q1: -R-H-@-|-|-|-@-@-----|-
+                       | | |   |     |
+            q2: -R-H---@-|-|---@-@---|-
+                         | |     |   |
+            q3: -R-H-----@-|-----@-@-|-
+                           |       | |
+            q4: -R-H-------@-------@-@-
+            
+        quirk url:
+            https://algassert.com/quirk#circuit=%7B%22cols%22%3A%5B%5B%22Z%22%2C%22H%22%2C%22H%22%2C%22H%22%2C%22H%22%5D%2C%5B%22X%22%2C%22%E2%80%A2%22%5D%2C%5B%22X%22%2C1%2C%22%E2%80%A2%22%5D%2C%5B%22X%22%2C1%2C1%2C%22%E2%80%A2%22%5D%2C%5B%22X%22%2C1%2C1%2C1%2C%22%E2%80%A2%22%5D%2C%5B%22%E2%80%A2%22%2C%22Z%22%5D%2C%5B1%2C%22%E2%80%A2%22%2C%22Z%22%5D%2C%5B1%2C1%2C%22%E2%80%A2%22%2C%22Z%22%5D%2C%5B1%2C1%2C1%2C%22%E2%80%A2%22%2C%22Z%22%5D%2C%5B%22Z%22%2C1%2C1%2C1%2C%22%E2%80%A2%22%5D%5D%7D
+    '
+    - '6 two-qubit gates.
+    
+        stim circuit: stim.Circuit(""" 
+            # Stabilizer Flows:
+            # X____ -> XXXXX
+            # Z____ -> ZZZZZ
+            # _____ -> XZZX_
+            # _____ -> _XZZX
+            # _____ -> X_XZZ
+            # _____ -> ZX_XZ
+            
+            R 1 2 3 4
+
+            YCX 0 3
+            XCX 0 4
+            ZCX 0 2
+            XCX 1 2
+            YCX 1 3
+            XCX 1 4
+
+            SQRT_X 0
+            H
+            S 3
+            C_XYZ 2
+            C_ZYX 4
+            X 2
+            Y 1 3
+        """)
+
+        text diagram:
+            q0: ---Y-X-@-------SQRT_X---
+                   | | |
+            q1: -R-|-|-|-X-Y-X--------Y-
+                   | | | | | |
+            q2: -R-|-|-X-X-|-|-C_XYZ--X-
+                   | |     | |
+            q3: -R-X-|-----X-|-S------Y-
+                     |       |
+            q4: -R---X-------X-C_ZYX----
+
+        quirk URL:
+            https://algassert.com/quirk#circuit=%7B%22cols%22%3A%5B%5B%22Y%22%2C1%2C1%2C%22%E2%8A%96%22%5D%2C%5B%22X%22%2C1%2C1%2C1%2C%22%E2%8A%96%22%5D%2C%5B%22Z%22%2C1%2C%22%E2%8A%96%22%5D%2C%5B1%2C%22X%22%2C%22%E2%8A%96%22%5D%2C%5B1%2C%22Y%22%2C1%2C%22%E2%8A%96%22%5D%2C%5B1%2C%22X%22%2C1%2C1%2C%22%E2%8A%96%22%5D%2C%5B%22X%5E%C2%BD%22%2C1%2C%22Z%5E-%C2%BD%22%2C%22Z%5E%C2%BD%22%2C%22H%22%5D%2C%5B1%2C1%2C%22H%22%2C1%2C%22Z%5E%C2%BD%22%5D%2C%5B1%2C%22Y%22%2C%22X%22%2C%22Y%22%5D%5D%7D
+    '
   transversal_gates: 'Pauli gates are transversal, along with a non-Pauli Hadamard-phase gate \(SH\) and three-qubit Clifford operation \(M_3\) \cite{arxiv:quant-ph/9702029,arxiv:quant-ph/9705052}.
   These realize the \(2T\) binary tetrahedral subgroup of \(SU(2)\).
   The code does not admit any non-Clifford transversal gates \cite{arXiv:quant-ph/9704043}.


### PR DESCRIPTION
This PR adds circuit diagrams, parseable stim circuits, and quirk links for the encoders on the [[5,1,3]] page. It also adds a 6-two-qubit gate encoder.

I ran into several problems trying to make these edits that mean the PR is incomplete and needs to pushed through be someone more knowledgeable about the workings of the site.

First, I wasn't able to get yarn working. So I have no way to preview the page. I have no idea if this looks right or is getting completely garbled. (This has always been my experience with node. And all the help about it that I find online is asking me to do dangerous things like pipe curl directly into bash.)

Second, I don't know what syntax you use to define a code block. The circuit diagrams and the computer-parsable stim circuits should be in code blocks.

Third, I'm not sure how to add the circuits in a verified way where anything actually checks that they work? Any kind of big repository of circuits like this needs some way to make sure its contents are actually accurate, or it will be full of mistakes. Circuits are *incredibly* easy to typo, and very hard to debug when there is a typo. (As an example... I am *extremely* suspicious that the "four CCZ" decoder circuit claim on the [[5,1,3]] page is totally wrong.) I wrote code to verify the circuits I'm adding:

```
from typing import Iterable, Optional

import stim


def verify_flow(
        circuit: stim.Circuit,
        *,
        start: Optional[stim.PauliString] = None,
        end: Optional[stim.PauliString] = None,
        measurements: Iterable[int] = (),
        allow_negated: bool = False):

    def do_controlled_pauli_string(
            sim: stim.TableauSimulator,
            control: int,
            paulis: Optional[stim.PauliString]):
        if paulis is None:
            return
        if paulis.sign == -1:
            sim.z(control)
        elif paulis.sign != +1:
            raise NotImplementedError(f'{paulis=}')
        for q, p in enumerate(paulis):
            if p == 1:
                sim.cx(control, q)
            elif p == 2:
                sim.cy(control, q)
            elif p == 3:
                sim.cz(control, q)
    
    q = circuit.num_qubits
    t = stim.TableauSimulator()
    t.reset_x(q)
    do_controlled_pauli_string(sim=t, control=q, paulis=start)
    t.do(circuit)
    do_controlled_pauli_string(sim=t, control=q, paulis=end)
    ms = t.current_measurement_record()
    for m in measurements:
        if ms[m]:
            t.z(q)
    p = t.peek_x(q)
    if p == 0:
        raise ValueError(f"Flow {start!r}->{end!r} was random.")
    if p == -1 and not allow_negated:
        raise ValueError(f"Flow {start!r}->{end!r} was deterministic, but negated.")


circuit1 = stim.Circuit("""
    R 1 2 3 4

    YCX 0 3
    XCX 0 4
    ZCX 0 2
    XCX 1 2
    YCX 1 3
    XCX 1 4

    SQRT_X 0
    H
    S 3
    C_XYZ 2
    C_ZYX 4

    X 2
    Y 1 3
""")
circuit2 = stim.Circuit("""
            R 1 2 3 4
            TICK
            
            Z 0
            H 1 2 3 4
            TICK
        
            CX 1 0
            TICK
            CX 2 0
            TICK
            CX 3 0
            TICK
            CX 4 0
            TICK
            CZ 0 1
            TICK
            CZ 1 2
            TICK
            CZ 2 3
            TICK
            CZ 3 4
            TICK
            CZ 4 0
""")

for circuit in [circuit1, circuit2]:
    print(circuit.diagram())

    verify_flow(circuit, end=stim.PauliString("XZZX_"))
    verify_flow(circuit, end=stim.PauliString("ZZX_X"))
    verify_flow(circuit, end=stim.PauliString("ZX_XZ"))
    verify_flow(circuit, end=stim.PauliString("X_XZZ"))
    verify_flow(circuit, start=stim.PauliString("X____"), end=stim.PauliString("XXXXX"))
    verify_flow(circuit, start=stim.PauliString("Z____"), end=stim.PauliString("ZZZZZ"))
```

Probably there should actually be special functionality for adding circuits, where the diagrams and source code and external URLs and verification all source from a common syntactical block unique to the site.