### PR TITLE
Update squeezed_fock_state.yml

### DIFF
--- a/codes/quantum/oscillators/uncategorized/squeezed_fock_state.yml
+++ b/codes/quantum/oscillators/uncategorized/squeezed_fock_state.yml
@@ -19,7 +19,7 @@ description: |
   |\overline{0}\rangle&=S(r)|1\ket\\|\overline{1}\rangle&=S(-r)|1\ket~,
   \end{split}
   \end{align}
-  where \(S(\pm r)\) is the squeezing operator with squeezing parameter \(\pmr\).
+  where \(S(\pm r)\) is the squeezing operator with squeezing parameter \(\pm r\).
 
 protection: 'The code approximately protects against loss and dephasing errors, becoming exact in the \(r\to\infty\) limit.'
 

--- a/users/users_db.yml
+++ b/users/users_db.yml
@@ -450,6 +450,10 @@
   name: 'Cella Kove'
   githubusername: viola1963
 
+- user_id: PurvaThakre
+  name: 'Purva Thakre'
+  githubusername: purva-thakre
+
 #
 # Core members -- add 'zooteam: core' and 'zoorole: <role>' to each entry.
 #


### PR DESCRIPTION
Fixes a minor typo in `Squeezed fock-state code`

![image](https://github.com/errorcorrectionzoo/eczoo_data/assets/66048318/4f1b5642-fec6-478a-bad7-c25fd077f019)

## Checklist:

I remembered to:

- [x] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

