### PR TITLE
Update double_semion.yml

### DIFF
--- a/codes/quantum/qudits/stabilizer/topological/double_semion.yml
+++ b/codes/quantum/qudits/stabilizer/topological/double_semion.yml
@@ -12,7 +12,7 @@ introduced: '\cite{arXiv:cond-mat/0404617,arxiv:2112.11394}'
 
 description: |
   Modular-qudit stabilizer code with qudit dimension \(q=4\) that is characterized by the 2D double semion topological phase. The code can be obtained from the \(\mathbb{Z}_4\) surface code by \hyperref[topic:code-switching]{condensing} the anyon \(e^2 m^2\) \cite{arxiv:2211.03798}.
-  Originally formulated as a non-stabilizer qubit code \cite{arXiv:cond-mat/0404617}, which can be extended to other spatial dimensions \cite{arxiv:1507.05676}.
+  Originally formulated as a non-stabilizer qubit code \cite{arXiv:cond-mat/0404617}, which can be extended to other spatial dimensions \cite{arxiv:1507.05676}, and later a non-Pauli stabilizer qubit code \cite{arXiv:2001.11516}.
 
   This stabilizer code family is inequivalent to a CSS code via a Clifford circuit whose depth does not scale with \(n\) \cite[Thm. 1.1]{arxiv:1506.08883}.
   This is because the double semion phase has a sign problem \cite{arxiv:1506.08883,arxiv:2005.05343}, and existence of such a Clifford circuit would allow one to construct a code Hamiltonian that is free of such a problem.
@@ -21,21 +21,21 @@ description: |
 relations:
   parents:
     - code_id: tqd_abelian
-      detail: 'When treated as ground states of the code Hamiltonian, the code states realize double-semion topological order, a topological phase of matter that also exists in twisted \(\mathbb{Z}_2\) gauge theory \cite{doi:10.1007/BF02096988}.'
+      detail: 'When treated as ground states of the code Hamiltonian, the code states realize double-semion topological order, a topological phase of matter that exists as the deconfined phase of the twisted \(\mathbb{Z}_2\) gauge theory in two dimensions \cite{doi:10.1007/BF02096988}.'
   cousins:
     - code_id: surface
-      detail: 'The double semion phase also has a realization in terms of qubits \cite{arXiv:cond-mat/0404617} that can be compared to the qubit surface code. There is a logical basis for both the toric and double-semion codes where each codeword is a superposition of states corresponding to all noncontractible loops of a particular homotopy type. The superposition is equal for the toric code, whereas some loops appear with a \(-1\) coefficient for the double semion.'
+      detail: 'The double semion phase also has a realization in terms of qubits \cite{arXiv:cond-mat/0404617} that can be compared to the qubit surface code. There is a logical basis for both the toric and double-semion codes where each codeword is a superposition of states corresponding to all noncontractible loops of a particular homotopy type. The superposition is equal for the toric code, whereas an odd number of loops appear with a \(-1\) coefficient for the double semion.'
     - code_id: qudit_surface
-      detail: 'The anyon fusion rules for the double-semion code and the \(\mathbb{Z}_4\) surface code are the same, but exchange statistics are different. The double-semion code can be obtained from the \(\mathbb{Z}_4\) surface code by \hyperref[topic:code-switching]{condensing} the anyon \(e^2 m^2\) \cite{arxiv:2211.03798} or by \hyperref[topic:gauging-out]{gauging out} the one-form symmetry associated with said anyon \cite[Footnote 18]{arxiv:2211.03798}.'
+      detail: 'The exchange statistics of the anyon for the double-semion code coincides with a subset of anyons in the \(\mathbb{Z}_4\), but the fusion rules are different. The double-semion code can be obtained from the \(\mathbb{Z}_4\) surface code by \hyperref[topic:code-switching]{condensing} the anyon \(e^2 m^2\) \cite{arxiv:2211.03798} or by gauging the one-form symmetry associated with said anyon \cite[Footnote 20]{arxiv:2211.03798}.'
 
 
 # Begin Entry Meta Information
 _meta:
   # Change log - most recent first
   changelog:
-    - user_id: VictorVAlbert
-      date: '2023-11-28'
     - user_id: nathanan
+      date: '2024-03-26'
+    - user_id: VictorVAlbert
       date: '2023-11-28'
     - user_id: VictorVAlbert
       date: '2021-12-29'


### PR DESCRIPTION
Added reference for non-Pauli stabilizer code

Changed "gauging out" to gauging, as the footnote referenced refers to the latter.

Expanded some details

