### PR TITLE
Change ``[10,2,4]]`` Carbon code to ``[[12, 2, 4]]`` Carbon code

### DIFF
--- a/codes/quantum/qubits/small_distance/small/carbon.yml
+++ b/codes/quantum/qubits/small_distance/small/carbon.yml
@@ -7,12 +7,12 @@ code_id: carbon
 physical: qubits
 logical: qubits
 
-name: '\([[10,2,4]]\) carbon code'
+name: '\([[12,2,4]]\) carbon code'
 short_name: 'Carbon'
 introduced: '\cite{arxiv:2404.02280}'
 
 description: |
-  Self-dual ten-qubit CSS code.
+  Self-dual twelve-qubit CSS code.
 
 features:
   transversal_gates:

--- a/codes/quantum/qubits/small_distance/small/carbon.yml
+++ b/codes/quantum/qubits/small_distance/small/carbon.yml
@@ -39,3 +39,5 @@ _meta:
   changelog:
     - user_id: VictorVAlbert
       date: '2024-04-04'
+    - user_id: vtomole
+      date: '2024-04-10'

--- a/users/users_db.yml
+++ b/users/users_db.yml
@@ -472,6 +472,12 @@
 - user_id: FerozAhmad
   name: 'Feroz Ahmad'
   githubusername: Fe-r-oz
+  
+- user_id: vtomole
+  name: 'Victory Omole'
+  githubusername: vtomole
+  gscholaruser: 'CmosrmsAAAAJ'
+  pageurl: 'https://vtomole.com/'
 
 #
 # Core members -- add 'zooteam: core' and 'zoorole: <role>' to each entry.


### PR DESCRIPTION


## Modified Codes:

**Carbon code**:
- Change to ``[[12, 2, 4]]`` Carbon code based on https://scirate.com/arxiv/2404.02280 because the main citation for this code doesn't mention the ``[[10, 2, 4]]`` Carbon code.

I remembered to:

- [x] Include relevant citations I could think of (with `\cite{...}`)

- [x] Create links to the other referenced codes (with
      `\hyperref[code:...]{...}`)

- [x] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

