### PR TITLE
Add fault-tolerant logical state preparation for several quantum codes

### DIFF
--- a/codes/quantum/qubits/small_distance/small/shor_nine.yml
+++ b/codes/quantum/qubits/small_distance/small/shor_nine.yml
@@ -52,6 +52,8 @@ protection: 'The code detects two-qubit errors or corrects an arbitrary single-q
 features:
   decoders:
     - 'Bit- and phase-flip circuits utilize CNOT and Hadamard gates (\cite{doi:10.1201/9781420012293}, Fig. 10.6).'
+  fault_tolerance:
+    - 'Fault-tolerant logical zero and logical plus state preparation \cite{arxiv:2402.17761}.'
 
 realizations:
   - 'Trapped-ion qubits: state preparation with 98.8(1)\% and 98.5(1)\% fidelity for state \(|\overline{0}\rangle\) and \(|\overline{1}\rangle\), respectively, by N. Linke group \cite{arxiv:2104.01205}. Variants of the code to handle coherent noise studied and realized by K. Brown and C. Monroe groups \cite{arxiv:2105.05068}.'
@@ -82,6 +84,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: remmyzen
+      date: '2024-07-15'
     - user_id: VictorVAlbert
       date: '2022-06-29'
     - user_id: VictorVAlbert

--- a/codes/quantum/qubits/small_distance/small/stab_5_1_3.yml
+++ b/codes/quantum/qubits/small_distance/small/stab_5_1_3.yml
@@ -59,6 +59,7 @@ features:
     - 'Pieceable fault-tolerant CZ, CNOT, and CCZ gates \cite{arxiv:1603.03948}.'
     - 'Syndrome measurement can be done with two ancillary flag qubits \cite{arxiv:1705.02329}.
     The depth of syndrome extraction circuits can be lowered by using past syndrome values \cite{arxiv:2305.00784}.'
+    - 'Fault-tolerant logical one and logical minus state preparation \cite{arxiv:2402.17761}.'
 
 realizations:
   - 'NMR: Implementation of perfect error correcting code on 5 spin subsystem of labeled crotonic acid for quantum network benchmarking \cite{arxiv:quant-ph/0101034}. Single-qubit logical gates \cite{arxiv:1208.4797}. Magic-state distillation using 7-qubit device \cite{arxiv:1103.2178}.'
@@ -119,6 +120,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: RemmyZen
+      date: '2024-07-15'
     - user_id: VictorVAlbert
       date: '2022-08-10'
     - user_id: AleksanderKubica

--- a/codes/quantum/qubits/small_distance/small/stab_5_1_3.yml
+++ b/codes/quantum/qubits/small_distance/small/stab_5_1_3.yml
@@ -59,7 +59,7 @@ features:
     - 'Pieceable fault-tolerant CZ, CNOT, and CCZ gates \cite{arxiv:1603.03948}.'
     - 'Syndrome measurement can be done with two ancillary flag qubits \cite{arxiv:1705.02329}.
     The depth of syndrome extraction circuits can be lowered by using past syndrome values \cite{arxiv:2305.00784}.'
-    - 'Fault-tolerant logical one and logical minus state preparation \cite{arxiv:2402.17761}.'
+    - 'Fault-tolerant logical one and logical minus state preparation in all-to-all and 2D grid connectivity \cite{arxiv:2402.17761}.'
 
 realizations:
   - 'NMR: Implementation of perfect error correcting code on 5 spin subsystem of labeled crotonic acid for quantum network benchmarking \cite{arxiv:quant-ph/0101034}. Single-qubit logical gates \cite{arxiv:1208.4797}. Magic-state distillation using 7-qubit device \cite{arxiv:1103.2178}.'

--- a/codes/quantum/qubits/small_distance/small/stab_5_1_3.yml
+++ b/codes/quantum/qubits/small_distance/small/stab_5_1_3.yml
@@ -120,7 +120,7 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
-    - user_id: RemmyZen
+    - user_id: remmyzen
       date: '2024-07-15'
     - user_id: VictorVAlbert
       date: '2022-08-10'

--- a/codes/quantum/qubits/small_distance/small/steane/steane.yml
+++ b/codes/quantum/qubits/small_distance/small/steane/steane.yml
@@ -70,6 +70,7 @@ features:
     - 'A fault-tolerant universal gate set can be done via code switching between the Steane code and the \([[10,1,2]]\) code \cite{arxiv:2403.13732}.'
     - 'Fault-tolerant logical zero and magic state preparation \cite{doi:10.1038/srep19578}.
     Magic-state preparation converts unbiased noise into biased noise \cite{arxiv:2401.10982}.'
+    - 'Fault-tolerant logical zero and logical plus state preparation on all-to-all and 2D grid qubit connectivity \cite{arxiv:2402.17761}.'
     - 'Pieceable fault-tolerant CCZ gate \cite{arxiv:1603.03948}.'
     - 'Syndrome measurement can be done with ancillary flag qubits \cite{arxiv:1612.04795,arxiv:1705.02329} or with no extra qubits \cite{doi:10.1088/2058-9565/abc6f4}.
     The depth of syndrome extraction circuits can be lowered by using past syndrome values \cite{arxiv:2305.00784}.'
@@ -131,6 +132,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: remmyzen
+      date: '2024-07-15'
     - user_id: EricHuang
       date: '2024-03-18'
     - user_id: VictorVAlbert

--- a/codes/quantum/qubits/stabilizer/topological/color/3d_color/stab_15_1_3.yml
+++ b/codes/quantum/qubits/stabilizer/topological/color/3d_color/stab_15_1_3.yml
@@ -34,6 +34,7 @@ features:
     - 'Numerical study of concatenated thresholds of logical CNOT gates for various codes against depolarizing noise \cite{arxiv:0711.1556}.'
 
   fault_tolerance:
+    - 'Fault-tolerant logical zero and logical plus state preparation \cite{arxiv:2402.17761}.'
     - 'A fault-tolerant universal gate set can be done via code switching between the Steane code and the \([[15,1,3]]\) code \cite{arxiv:1304.3709,arxiv:1403.2734,arxiv:1703.03860,arxiv:2210.14074}.'
 
 
@@ -64,6 +65,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: remmyzen
+      date: '2024-07-15'
     - user_id: balopat
       date: '2023-03-30'
     - user_id: VictorVAlbert

--- a/codes/quantum/qubits/stabilizer/topological/surface/2d_surface/surface-17.yml
+++ b/codes/quantum/qubits/stabilizer/topological/surface/2d_surface/surface-17.yml
@@ -23,6 +23,9 @@ features:
     - 'Pauli gates, CNOT gate, and \(H\) gate (with relabeling).'
   decoders:
     - 'Lookup table \cite{arxiv:1404.3747}.'
+  fault_tolerance:
+    - 'Measurement-free fault-tolerant logical zero state preparation on nearest-neighbor qubit connectivity \cite{arxiv:2303.17211} '
+    - 'Fault-tolerant logical zero and logical minus state preparation in all-to-all and 2D grid connectivity with flag qubits \cite{arxiv:2402.17761}.'
 
 notes:
   - 'Subject of various numerical studies examining the system for noises and architectures specific to trapped ions \cite{arxiv:1404.3747,arxiv:1710.01378,arxiv:1910.08495} and superconducting circuits \cite{arxiv:1612.08208,arxiv:1703.04136,arxiv:2002.07119}'
@@ -49,6 +52,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: remmyzen
+      date: '2024-07-15'
     - user_id: KennethRBrown
       date: '2022-06-12'
     - user_id: VictorVAlbert

--- a/codes/quantum/qubits/stabilizer/topological/surface/2d_surface/surface-17.yml
+++ b/codes/quantum/qubits/stabilizer/topological/surface/2d_surface/surface-17.yml
@@ -24,8 +24,8 @@ features:
   decoders:
     - 'Lookup table \cite{arxiv:1404.3747}.'
   fault_tolerance:
-    - 'Measurement-free fault-tolerant logical zero state preparation on nearest-neighbor qubit connectivity \cite{arxiv:2303.17211} '
-    - 'Fault-tolerant logical zero and logical minus state preparation in all-to-all and 2D grid connectivity with flag qubits \cite{arxiv:2402.17761}.'
+    - 'Measurement-free fault-tolerant logical zero state preparation in nearest-neighbor qubit connectivity \cite{arxiv:2303.17211}.'
+    - 'Fault-tolerant logical zero and logical plus state preparation in all-to-all and 2D grid connectivity with flag qubits \cite{arxiv:2402.17761}.'
 
 notes:
   - 'Subject of various numerical studies examining the system for noises and architectures specific to trapped ions \cite{arxiv:1404.3747,arxiv:1710.01378,arxiv:1910.08495} and superconducting circuits \cite{arxiv:1612.08208,arxiv:1703.04136,arxiv:2002.07119}'

--- a/users/users_db.yml
+++ b/users/users_db.yml
@@ -506,6 +506,12 @@
   name: 'Austin He'
   githubusername: Austin-He
 
+- user_id: remmyzen
+  name: 'Remmy Zen'
+  gscholaruser: 'YgCYIrIAAAAJ'
+  githubusername: remmyzen
+  pageurl: 'https://remmyzen.github.io/'
+
 #
 # Core members -- add 'zooteam: core' and 'zoorole: <role>' to each entry.
 #


### PR DESCRIPTION
Add fault-tolerant logical state preparations for several quantum codes taken from [this paper](https://arxiv.org/abs/2402.17761) and [this paper](https://arxiv.org/abs/2303.17211).

## Modified Codes:

**[[5,1,3]] perfect code**:
- added fault-tolerant logical one and logical minus state preparation from [this paper](https://arxiv.org/abs/2402.17761).
- expanded citations

**[[7,1,3]] Steane code**:
- added fault-tolerant logical zero and logical plus state preparation from [this paper](https://arxiv.org/abs/2402.17761).
- expanded citations

**[[9,1,3]] Shor code**:
- added fault-tolerant logical zero and logical plus state preparation from [this paper](https://arxiv.org/abs/2402.17761).
- expanded citations

**[[9,1,3]] Surface-17 code**:
- added measurement-free fault-tolerant logical zero state preparation from [this paper](https://arxiv.org/abs/2303.17211).
- added fault-tolerant logical zero and logical plus state preparation from [this paper](https://arxiv.org/abs/2402.17761).
- expanded citations

**[[15,1,3]] Reed-Muller code**:
- added fault-tolerant logical zero and logical plus state preparation from [this paper](https://arxiv.org/abs/2402.17761).
- expanded citations


## Checklist:

I remembered to:

- [x] Include relevant citations I could think of (with `\cite{...}`)

- [x] Create links to the other referenced codes (with
      `\hyperref[code:...]{...}`)

- [x] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

