### PR TITLE
Update quantum_divisible.yml

### DIFF
--- a/codes/quantum/qubits/stabilizer/magic/k-divisible/quantum_divisible.yml
+++ b/codes/quantum/qubits/stabilizer/magic/k-divisible/quantum_divisible.yml
@@ -13,7 +13,7 @@ introduced: '\cite{arxiv:1302.3240,arxiv:1606.01904,arxiv:1709.02832}'
 
 description: |
   A level-\(\nu\) quantum divisible code is a CSS code whose \(X\)-type stabilizers form a \(\nu\)-even linear binary code in the \hyperref[topic:binary-symplectic-representation]{symplectic representation} and which admits a transversal gate at the \(\nu\)th level of the \term{Clifford hierarchy}.
-  A CSS code is \textit{doubly even} (\textit{triply even}) if all \(X\)-type stabilizer generators have weight divisible by four (eight), i.e., if they form a doubly even (triply even) linear binary code.
+  A CSS code is \textit{doubly even} (\textit{triply even}) if all \(X\)-type stabilizers have weight divisible by four (eight), i.e., if they form a doubly even (triply even) linear binary code.
 
   More formally \cite{arxiv:2109.13481,arxiv:2204.13176}, a quantum divisible code is a CSS code defined from two linear binary codes \(C_{1,2}\) such that all weights in \(C_2\) share a common divisor \(\Delta > 1\), and all weights in each coset of \(C_2\) in \(C_1\) are congruent to \(\Delta\).
   For example \cite{arxiv:2204.13176}, if \(C_2\) is the first-order RM\((1,m)\) code, and \(C_1/ C_2\) consists of quadratic forms with a bounded rank, then \([[n = 2m − 1, 1 \leq k \leq 1 + \sum_{i=1}^{m-4}(m − i), d = 3]]\) is a family of quantum divisible codes.


### PR DESCRIPTION
The doubly even condition requires every stabilizer elements, rather than merely the generators, to be at weight of 4n (See page 5 of https://arxiv.org/pdf/1509.03239)

[Please provide a brief description of your suggested changes here. If you are
simply providing new codes / modifying existing ones, simply describe your
changes below. Don't forget to remove this text.]

## Modified Codes:

**quantum divisible code**:
- statement correction



## Checklist:

I remembered to:

- [x] Include relevant citations I could think of (with `\cite{...}`)

- [x] Create links to the other referenced codes (with
      `\hyperref[code:...]{...}`)

- [x] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

