### PR TITLE
Update shor_nine.yml: fix typo in the stabilizer tableau.

### DIFF
--- a/codes/quantum/qubits/small_distance/small/shor_nine.yml
+++ b/codes/quantum/qubits/small_distance/small/shor_nine.yml
@@ -31,7 +31,7 @@ description: |
     I & I & I & I & I & I & Z & Z & I \\
     I & I & I & I & I & I & I & Z & Z \\
     X & X & X & X & X & X & I & I & I \\
-    X & X & X & X & X & X & I & I & I
+    I & I & I & X & X & X & X & X & X
     \end{bmatrix}~.
   \end{align}
   The \hyperref[topic:encoder-respecting]{encoder-respecting form} of the Shor code is a star-shaped tree graph \cite{arxiv:2411.14448}.


### PR DESCRIPTION
Fixing an obvious typo in the stabilizer tableau of Shor's code. Previously, the same $X$-type stabilizer was written twice.