### PR TITLE
Add toric codes with rotated boundary conditions

### DIFF
--- a/codes/quantum/qubits/stabilizer/topological/surface/2d_surface/toric/toric.yml
+++ b/codes/quantum/qubits/stabilizer/topological/surface/2d_surface/toric/toric.yml
@@ -38,6 +38,8 @@ protection: |
   Toric code on an \(L\times L\) torus is a \([[2L^2,2,L]]\) CSS code.
   The number of error patterns can be used to bound the ground-state energy of a \(\pm J\) Ising model \cite{arxiv:cond-mat/0405313}.
 
+  Different choices for the periodic boundary conditions yield higher rate CSS codes with parameters \([[L^2+1,2,L]]\) for odd \(L\) \cite{arXiv:quant-ph/0605094}, and \([[L^2,2,L]]\) for even \(L\) \cite{manual:{C. D. Albuquerque et al., On Toric Quantum Codes, \emph{Int. J. Pure Appl. Math.} 50, 221–-226 (2009).} \url{https://www.ijpam.eu/contents/2009-50-2/12/index.html}.
+
   Coherent physical errors are expected to become incoherent logical errors under syndrome measurement; see corroborating numerical studies performed via the Majorana mapping \cite{arxiv:1710.02270} as well as analytical bounds \cite{arxiv:1912.04319}.
 
 features:


### PR DESCRIPTION
[Please provide a brief description of your suggested changes here. If you are
simply providing new codes / modifying existing ones, simply describe your
changes below. Don't forget to remove this text.]

## Modified Codes:

**Toric code**:
- added toric codes with rotated boundary conditions, citing work by Bombin & Martin-Delgado, as well as other work by de Albuquerque.

## Checklist:

I remembered to:

- [X] Include relevant citations I could think of (with `\cite{...}`)

- [X] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

