### PR TITLE
add qldpc notation

### DIFF
--- a/codes/quantum/properties/stabilizer/qldpc/qldpc.yml
+++ b/codes/quantum/properties/stabilizer/qldpc/qldpc.yml
@@ -13,7 +13,7 @@ alternative_names:
 
 description: |
   Member of a family of \([[n,k,d]]\) stabilizer codes for which the number of sites participating in each stabilizer generator and the number of stabilizer generators that each site participates in are both bounded by a constant \(w\) as \(n\to\infty\); can be denoted by \([[n,k,d,w]]\).
-  Sometimes, the two parameters are explicitly stated: each site of an an \((l,w)\)\textit{-regular QLDPC code} is acted on by \(\leq l\) generators of weight \(\leq w\).
+  Sometimes, the two parameters are explicitly stated: each site of an an \((l,w)\)\textit{-regular QLDPC code} is acted on by \(\leq l\) generators of weight \(\leq w\). For finite size codes the notation \([[n,k,d]]_{(w,q)}\) has also been used, where \(w\) and \(q\) denote the maximum stabilizer weight and qubit degree.
   QLDPC codes can correct many stochastic errors far beyond the distance, which may not scale as favorably.
   Together with more accurate, faster, and easier-to-parallelize measurements than those of general stabilizer codes, this property makes QLDPC codes interesting in practice.
 

--- a/codes/quantum/properties/stabilizer/qldpc/qldpc.yml
+++ b/codes/quantum/properties/stabilizer/qldpc/qldpc.yml
@@ -13,7 +13,7 @@ alternative_names:
 
 description: |
   Member of a family of \([[n,k,d]]\) stabilizer codes for which the number of sites participating in each stabilizer generator and the number of stabilizer generators that each site participates in are both bounded by a constant \(w\) as \(n\to\infty\); can be denoted by \([[n,k,d,w]]\).
-  Sometimes, the two parameters are explicitly stated: each site of an an \((l,w)\)\textit{-regular QLDPC code} is acted on by \(\leq l\) generators of weight \(\leq w\). For finite size codes the notation \([[n,k,d]]_{(w,q)}\) has also been used, where \(w\) and \(q\) denote the maximum stabilizer weight and qubit degree.
+  Sometimes, the two parameters are explicitly stated: each site of an an \((l,w)\)\textit{-regular QLDPC code} is acted on by \(\leq l\) generators of weight \(\leq w\). For finite size codes, the notation \([[n,k,d]]_{(w,q)}\) has also been used, where \(w\) and \(q\) denote the maximum stabilizer weight and qubit degree.
   QLDPC codes can correct many stochastic errors far beyond the distance, which may not scale as favorably.
   Together with more accurate, faster, and easier-to-parallelize measurements than those of general stabilizer codes, this property makes QLDPC codes interesting in practice.
 
@@ -166,6 +166,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: Austin-He
+      date: '2025-04-01'
     - user_id: VictorVAlbert
       date: '2022-10-02'
     - user_id: EugeneTang

--- a/codes/quantum/properties/stabilizer/qldpc/qldpc.yml
+++ b/codes/quantum/properties/stabilizer/qldpc/qldpc.yml
@@ -166,7 +166,7 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
-    - user_id: Austin-He
+    - user_id: AustinHe
       date: '2025-04-01'
     - user_id: VictorVAlbert
       date: '2022-10-02'

--- a/users/users_db.yml
+++ b/users/users_db.yml
@@ -556,7 +556,8 @@
   pageurl: 'https://vtomole.com/'
 
 - user_id: AustinHe
-  name: 'Austin He'
+  name: 'Austin Yubo He'
+  gscholaruser: 'MOYd3tAAAAAJ'
   githubusername: Austin-He
 
 - user_id: remmyzen


### PR DESCRIPTION
## Modified Codes:

**qldpc code**:
- added brief note on \([[n,k,d]]_{(w,q)}\) notation recently used in our paper to make some compact tables of finite size qldpc codes. 

## Checklist:

I remembered to:

- [ X] Include relevant citations I could think of (with `\cite{...}`)

- [ X] Create links to the other referenced codes (with
      `\hyperref[code:...]{...}`)

- [ X] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

