### PR TITLE
Fix typo in reference

### DIFF
--- a/codes/quantum/qubits/stabilizer/topological/surface/hyperbolic/2d_hyperbolic/stellated_dodecahedron_css.yml
+++ b/codes/quantum/qubits/stabilizer/topological/surface/hyperbolic/2d_hyperbolic/stellated_dodecahedron_css.yml
@@ -22,7 +22,7 @@ features:
   transversal_gates:
     - '\hyperref[topic:clifford]{Clifford group} of four of the eight logical qubits can be done by transversal gates combined with qubit permutations \cite{arxiv:2202.06647}.'
   decoders:
-    - 'Fault-tolerant parity-check schedules whose performance is similar to those of the surface-17 code, but with qubit overhead reduced by a factor 2.6 \cite{manual:{J. Q. Broshuis, "The Small Stellated Dodecahedron Code: Finding Interleaved Measurement Schedules", Master''s thesis. \href{https://resolver.tudelft.nl/uuid:4e6852c1-b18d-4b6b-8cc4-dc4587bff260}{report-link} \href{https://github.com/MarcSerraPeralta/ssd-scheduler}{GitHub-link}}}.'
+    - 'Fault-tolerant parity-check schedules whose performance is similar to those of the surface-17 code, but with qubit overhead reduced by a factor 2.6 \cite{manual:{J. Q. Broshuis, "The Small Stellated Dodecahedron Code: Finding Interleaved Measurement Schedules", Bachelor''s thesis. \href{https://resolver.tudelft.nl/uuid:4e6852c1-b18d-4b6b-8cc4-dc4587bff260}{report-link} \href{https://github.com/MarcSerraPeralta/ssd-scheduler}{GitHub-link}}}.'
 
 
 relations:


### PR DESCRIPTION
## Modified Codes:

**Small stellated dodecahedron code**:
- Fixed typo in reference

## Checklist:

I remembered to:

- [x] Include relevant citations I could think of (with `\cite{...}`)

- [x] Create links to the other referenced codes (with
      `\hyperref[code:...]{...}`)

- [x] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

