### PR TITLE
Revise RM Majorana code parameters

### DIFF
--- a/codes/quantum/qubits/majorana/rm/majorana_reed_muller.yml
+++ b/codes/quantum/qubits/majorana/rm/majorana_reed_muller.yml
@@ -16,7 +16,7 @@ description: |
   Logical measurements are reduced to parity measurements of some subset of Majorana fermions in the code.
 
 protection: |
-  Code parameters are \([[2^m,2^m - \sum_{j=0}^{r} {m \choose j},2^r]]_{f}\), which are optimal per Majorana LP bounds for \(r=2\) and \(m=3,4\) \cite[Sec. 3.4]{arxiv:2502.14165}.
+  Code parameters are \([[2^{m-1},2^{m-1} - \sum_{j=0}^{r} {m \choose j},2^{r+1}]]_{f}\), which are optimal per Majorana LP bounds for \(r = 0\) and \(m \geq 1\), and \(r=1\) and \(m=4,5\) \cite[Sec. 3.4]{arxiv:2502.14165}.
 
 
 relations:
@@ -34,4 +34,4 @@ _meta:
     - user_id: VictorVAlbert
       date: '2025-10-27'
     - user_id: RuiOkada
-      date: '2025-10-27'
+      date: '2025-11-01'


### PR DESCRIPTION
Hi Victor, I just noticed that there were embarrassing off-by-one errors in my thesis for the code parameters of the RM Majorana code. These should be the correct parameters along with some optimal parameters. The new parameters should also be more indicative that r = 1 gives Hastings' family.

## Modified Codes:

**RM Majorana code**:
- Updated parameters and LP bound optimality conditions.

## Checklist:

I remembered to:

- [x] Include relevant citations I could think of (with `\cite{...}`)

- [x] Create links to the other referenced codes (with
      `\hyperref[code:...]{...}`)

- [x] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)