### PR TITLE
Add dual displacement code

### DIFF
--- a/codes/quantum/oscillators/dual_displacement.yml
+++ b/codes/quantum/oscillators/dual_displacement.yml
@@ -41,3 +41,8 @@ relations:
   parents:
     - code_id: oscillators_into_oscillators
       detail: 'Dual-displacement codes are oscillator-into-oscillator bosonic codes.'
+
+_meta:
+  changelog:
+    - user_id: FuchengGuo
+      date: '2026-04-23'

--- a/codes/quantum/oscillators/dual_displacement.yml
+++ b/codes/quantum/oscillators/dual_displacement.yml
@@ -41,8 +41,3 @@ relations:
   parents:
     - code_id: oscillators_into_oscillators
       detail: 'Dual-displacement codes are oscillator-into-oscillator bosonic codes.'
-
-_meta:
-  changelog:
-    - user_id: FuchengGuo
-      date: '2026-04-23'

--- a/codes/quantum/oscillators/dual_displacement.yml
+++ b/codes/quantum/oscillators/dual_displacement.yml
@@ -37,25 +37,10 @@ protection: |
   outer layer uses analog syndrome extraction to infer both the location
   and the magnitude of residual displacement errors.
 
-features: |
-  One proposed realization employs a seven-mode analog Steane encoding as
-  the outer code together with GKP ancilla-assisted Gaussian error
-  suppression on every physical mode.
-
-  In the ideal small-noise regime, the inner layer reduces the variance
-  of Gaussian displacement noise by up to a factor of two, while the
-  outer layer corrects occasional large-shift events beyond the
-  correction range of the GKP layer.
-
 relations:
   parents:
     - code_id: oscillators_into_oscillators
       detail: 'Dual-displacement codes are oscillator-into-oscillator bosonic codes.'
-
-notes: |
-  A concatenated realization using an outer analog Steane code and an
-  inner GKP-assisted suppression layer was introduced in
-  \cite{arxiv:2512.00481}.
 
 _meta:
   changelog:

--- a/codes/quantum/oscillators/dual_displacement.yml
+++ b/codes/quantum/oscillators/dual_displacement.yml
@@ -1,0 +1,63 @@
+#######################################################
+## This is a code entry in the error correction zoo. ##
+##       https://github.com/errorcorrectionzoo       ##
+#######################################################
+
+code_id: dual_displacement
+physical: oscillators
+logical: oscillators
+
+name: 'Dual-displacement code'
+introduced: '\cite{arxiv:2512.00481}'
+
+description: |
+  An oscillator-into-oscillator bosonic code family designed to protect
+  continuous-variable logical information against displacement errors by
+  combining complementary protection mechanisms acting at different
+  displacement scales.
+
+  In one explicit realization, an inner GKP-assisted layer suppresses
+  small Gaussian displacement noise on each mode, while an outer analog
+  Steane layer corrects rare lattice-crossing events and other large
+  abrupt displacement errors that exceed the correctable range of the
+  inner layer.
+
+  Unlike conventional concatenation schemes that recursively apply
+  functionally similar codes, dual-displacement codes separate
+  error-mitigation roles: continuous Gaussian noise suppression at the
+  inner layer and analog syndrome-based correction of residual logical
+  displacement errors at the outer layer.
+
+protection: |
+  Protects against additive Gaussian displacement noise, lattice-crossing
+  errors induced by finite-spacing GKP decoding, and other abrupt large
+  displacement shifts.
+
+  The inner layer mitigates continuous small displacements, whereas the
+  outer layer uses analog syndrome extraction to infer both the location
+  and the magnitude of residual displacement errors.
+
+features: |
+  One proposed realization employs a seven-mode analog Steane encoding as
+  the outer code together with GKP ancilla-assisted Gaussian error
+  suppression on every physical mode.
+
+  In the ideal small-noise regime, the inner layer reduces the variance
+  of Gaussian displacement noise by up to a factor of two, while the
+  outer layer corrects occasional large-shift events beyond the
+  correction range of the GKP layer.
+
+relations:
+  parents:
+    - code_id: oscillators_into_oscillators
+      detail: 'Dual-displacement codes are oscillator-into-oscillator bosonic codes.'
+
+notes: |
+  A concatenated realization using an outer analog Steane code and an
+  inner GKP-assisted suppression layer was introduced in
+  \cite{arxiv:2512.00481}.
+
+_meta:
+  changelog:
+    - user_id: FuchengGuo
+      date: '2026-04-23'

--- a/users/users_db.yml
+++ b/users/users_db.yml
@@ -34,6 +34,9 @@
 
 #
 
+- user_id: FuchengGuo
+  name: 'Fucheng Guo'
+
 - user_id: BruceMiller
   name: 'Bruce R. Miller'
   githubusername: brucemiller


### PR DESCRIPTION
## New Codes

- **Dual-displacement code**

  Added a new oscillator-into-oscillator bosonic code entry based on the concatenated dual-displacement architecture introduced in arXiv:2512.00481.

## Notes

- Includes citation to the original paper.
- Added parent relation to `oscillators_into_oscillators`.
- Updated changelog metadata.