### PR TITLE
Added reference to published paper for Carbon and Tesseract Color codes

### DIFF
--- a/codes/quantum/qubits/small_distance/small/12/carbon.yml
+++ b/codes/quantum/qubits/small_distance/small/12/carbon.yml
@@ -47,7 +47,7 @@ features:
 
 
 realizations:
-  - 'Trapped-ion devices: Three rounds of error correction and post-selected fault-tolerant logical Bell-state preparation with logical error rates at least 5 times lower than physical rate on a quantum charge-coupled device (QCCD) \cite{arxiv:2305.03828} by Microsoft and Quantinuum \cite{arxiv:2404.02280}.'
+  - 'Trapped-ion devices: Three rounds of error correction and post-selected fault-tolerant logical Bell-state preparation with logical error rates at least 5 times lower than physical rate on a quantum charge-coupled device (QCCD) \cite{arxiv:2305.03828} by Microsoft and Quantinuum \cite{arxiv:2404.02280}. Updated data in published paper by the same authors includes up to ten rounds of error correction with logical error rates at least 51x lower than physical rate on a similar device \cite{doi:10.1038/s41586-026-10628-y}.'
 
 
 relations:
@@ -64,6 +64,8 @@ relations:
 # Begin Entry Meta Information
 _meta:
   changelog:
+    - user_id: MarcusPS
+      date: '2026-06-28'
     - user_id: VictorVAlbert
       date: '2026-06-08'
     - user_id: VictorVAlbert

--- a/codes/quantum/qubits/small_distance/small/16/stab_16_6_4.yml
+++ b/codes/quantum/qubits/small_distance/small/16/stab_16_6_4.yml
@@ -47,7 +47,7 @@ features:
     - 'Post-selected fault-tolerant syndrome extraction \cite{arxiv:2008.05051,arxiv:2112.03785}.'
 
 realizations:
-  - 'Trapped-ion devices: logical graph and GHZ states of up to 12 logical qubits constructed using three copies of the \([[16,4,2,4]]\) tesseract subsystem code, along with five rounds of post-selected fault-tolerant error correction in a device by Quantinuum \cite{arxiv:2409.04628}.'
+  - 'Trapped-ion devices: logical graph and GHZ states of up to 12 logical qubits constructed using three copies of the \([[16,4,2,4]]\) tesseract subsystem code, along with five rounds of post-selected fault-tolerant error correction in a device by Quantinuum \cite{arxiv:2409.04628,doi:10.1038/s41586-026-10628-y}.'
   - 'Neutral atom arrays: deep circuits and 1D-cluster-state creation using 96 logical qubits and hundreds of logical teleportations by the Lukin group \cite{arxiv:2506.20661}.'
 
 
@@ -78,6 +78,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: MarcusPS
+      date: '2026-06-28'
     - user_id: VictorVAlbert
       date: '2026-06-08'
     - user_id: VictorVAlbert


### PR DESCRIPTION

## Modified Codes:

**Carbon code**:
- added reference to published paper, described new data (10 rounds of error correction, >51x improvement over physical baseline)

**Tesseract color code**:
- added reference to published paper

## Checklist:

I remembered to:

- [X] Include relevant citations I could think of (with `\cite{...}`)

- [X] Create links to the other referenced codes (with
      `\hyperref[code:...]{...}`)

- [X] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

