### PR TITLE
Add Frontier decoder results

### DIFF
--- a/codes/quantum/qubits/stabilizer/qldpc/balanced_product/lp/bb/bb72.yml
+++ b/codes/quantum/qubits/stabilizer/qldpc/balanced_product/lp/bb/bb72.yml
@@ -22,6 +22,9 @@ description: |
 features:
   rate: 'Ancilla-added encoding rate is \(1/12\), using \(n_a=n=72\) ancilla qubits.'
 
+  decoders:
+    - 'The \href{https://github.com/aleverrier/frontier}{Frontier decoder}, a pruned ordered dynamic-programming decoder, was benchmarked under circuit-level noise using per-side detector error model matrices of size \(252\times 2232\); the reported full-FER results were compared with beam-search and Tesseract decoders \cite{arxiv:2606.20513}.'
+
 
 relations:
   parents:
@@ -32,6 +35,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: AnthonyLeverrier
+      date: '2026-07-22'
     - user_id: VictorVAlbert
       date: '2026-06-08'
     - user_id: VictorVAlbert

--- a/codes/quantum/qubits/stabilizer/qldpc/balanced_product/lp/bb/gross.yml
+++ b/codes/quantum/qubits/stabilizer/qldpc/balanced_product/lp/bb/gross.yml
@@ -40,6 +40,7 @@ features:
     - 'The GDG sliding-window decoder \cite{arxiv:2403.18901}, with a realization achieving a worst-case decoding latency of 3ms per window.'
     - 'AC decoder is faster than ordinary BP-OSD with no reduction of fidelity \cite{arxiv:2406.14527}.'
     - 'Transformer-based neural-network decoder \cite{arxiv:2504.13043}.'
+    - 'The \href{https://github.com/aleverrier/frontier}{Frontier decoder}, a pruned ordered dynamic-programming decoder, was benchmarked under circuit-level noise using per-side detector error model matrices of size \(936\times 8784\). At \(p=10^{-3}\), its reported full-FER comparison with beam-search and Tesseract decoders used an average retained frontier of fewer than 100 states \cite{arxiv:2606.20513}.'
 
   fault_tolerance:
     - 'Fault-tolerant modular quantum computing framework \cite{arxiv:2506.03094}.'
@@ -61,6 +62,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: AnthonyLeverrier
+      date: '2026-07-22'
     - user_id: VictorVAlbert
       date: '2026-06-08'
     - user_id: VictorVAlbert

--- a/codes/quantum/qubits/stabilizer/topological/color/2d_color/2d_color.yml
+++ b/codes/quantum/qubits/stabilizer/topological/color/2d_color/2d_color.yml
@@ -66,6 +66,7 @@ features:
     - 'Chromöbius, an open-source implementation of the Möbius decoder, works for many 2D color codes \cite{arxiv:2312.08813}.'
     - 'Concatenated MPWM decoder \cite{arxiv:2404.07482}.'
     - 'Syndrome extraction circuits based on superdense coding and a middle-out strategy \cite{arxiv:2312.08813}.'
+    - 'The \href{https://github.com/aleverrier/frontier}{Frontier decoder} was benchmarked on hexagonal color codes of distances \(9,13,17,21\) under code-capacity bit-flip noise, producing threshold curves consistent with the optimal scale \(p_c\simeq0.109\) while retaining at most \(K=1024\) frontier states \cite{arxiv:2606.20513}.'
 # Are we certain these work for all color code geometries?
 
 
@@ -105,6 +106,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: AnthonyLeverrier
+      date: '2026-07-22'
     - user_id: VictorVAlbert
       date: '2026-06-08'
     - user_id: VictorVAlbert

--- a/codes/quantum/qubits/stabilizer/topological/surface/2d_surface/rotated_surface/rotated_surface.yml
+++ b/codes/quantum/qubits/stabilizer/topological/surface/2d_surface/rotated_surface/rotated_surface.yml
@@ -46,6 +46,7 @@ features:
     - 'Local neural-network using 3D convolutions, combined with a separate global decoder \cite{arxiv:2208.01178}.'
     - 'Iterative CNOT decoder \cite{arxiv:2407.20976}.'
     - 'Fault-tolerant BP (FTBP) decoder \cite{arxiv:2409.18689}.'
+    - 'The \href{https://github.com/aleverrier/frontier}{Frontier decoder} was benchmarked under correlated Pauli code-capacity noise, with a crossing window close to the \(p\approx0.189\) maximum-likelihood threshold scale. In a circuit-level memory-\(Z\) experiment at \(p=0.002\), its fitted error-suppression coefficient was \(\Lambda\approx8.6\), compared with \(\Lambda\approx7.9\) for correlated MWPM \cite{arxiv:2606.20513}.'
   threshold:
     - 'Thresholds for various amounts of erasure, Pauli, correlated, and measurement noise are known \cite{arxiv:2408.00829,arxiv:2410.23779}.'
   fault_tolerance:
@@ -84,6 +85,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: AnthonyLeverrier
+      date: '2026-07-22'
     - user_id: VictorVAlbert
       date: '2026-06-08'
     - user_id: EricHuang

--- a/users/users_db.yml
+++ b/users/users_db.yml
@@ -34,6 +34,10 @@
 
 #
 
+- user_id: AnthonyLeverrier
+  name: 'Anthony Leverrier'
+  githubusername: aleverrier
+
 - user_id: TomaszAndrzejewski
   name: 'Tomasz Andrzejewski'
   githubusername: TomaszAnd


### PR DESCRIPTION
## Summary

- add the Frontier decoder to the existing BB72, gross-code, rotated-surface-code, and 2D-color-code entries
- cite Leverrier and Urbanke, [arXiv:2606.20513](https://arxiv.org/abs/2606.20513), and link the open-source implementation
- report the paper's code-capacity and detector-error-model results with their noise-model and decoding-scope qualifiers
- add Anthony Leverrier to the code-contributor registry

## Result scope

The BB entries identify the per-side detector error model matrix sizes and full-FER comparisons. The rotated-surface entry distinguishes correlated-Pauli code capacity from the circuit-level memory-Z experiment and its fitted error-suppression coefficient. The color-code entry identifies the hexagonal-code distances and code-capacity bit-flip setting.

This does not claim a DecoderBench result; the paper used its own benchmark corpora.

## Validation

- parsed all five changed YAML files with PyYAML 6.0.3
- ran the repository spell checker on all four changed code entries: zero issues
- ran `git diff --check`

The repository's pull-request CI will perform the full site build and citation-resolution check.
