### PR TITLE
Document improved asymptotic binary and spherical code bounds

### DIFF
--- a/codes/classical/bits/bits_into_bits.yml
+++ b/codes/classical/bits/bits_into_bits.yml
@@ -33,8 +33,11 @@ protection: |
 
 
 features:
-  rate: 'The rate of a binary code is usually defined as \(R=\frac{1}{n}\log_{2}K\) bits per symbol.
-  The maximum rate of a binary code with linear distance is upper bounded by the McEliece, Rodemich, Rumsey and Welch (MRRW) bound \cite{doi:10.1109/TIT.1977.1055688} (see Refs. \cite{doi:10.1007/s00454-008-9128-0,doi:10.1137/S0895480102408353,doi:10.1142/9789812832245_0002,doi:10.1134/S0032946006020025,arxiv:2104.14587,arxiv:2303.16619} for other proofs).'
+  rate: |
+    The rate of a binary code is usually defined as \(R=\frac{1}{n}\log_{2}K\) bits per symbol.
+    The maximum rate of a binary code with linear distance is upper bounded by the McEliece, Rodemich, Rumsey and Welch (MRRW) bound \cite{doi:10.1109/TIT.1977.1055688} (see Refs. \cite{doi:10.1007/s00454-008-9128-0,doi:10.1137/S0895480102408353,doi:10.1142/9789812832245_0002,doi:10.1134/S0032946006020025,arxiv:2104.14587,arxiv:2303.16619} for other proofs).
+    For every fixed relative distance \(0<\delta<1/2\), two-point linear-programming certificates strictly improve the optimized MRRW asymptotic upper bound for unrestricted binary codes \cite[Thm. 1.1]{manual:{OpenAI, “Improved Bounds for Binary and Spherical Codes”, Chapter 2 in \emph{Ten Advances in Mathematics and Theoretical Computer Science} (updated August 6, 2026), \href{https://cdn.openai.com/pdf/ten-proofs-oai.pdf}{URL}}}.
+    These are converse bounds on achievable rate; they do not supply code constructions, encoders, or decoders.
 
   general_gates:
     - 'The group of reversible binary operations is the permutation group \(S_{2^n}\) of all possible \(n\)-bit strings. Reversible gate sets have been classified \cite{arxiv:1504.05155}.'
@@ -64,6 +67,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: DevanshSehgal
+      date: '2026-08-07'
     - user_id: VictorVAlbert
       date: '2026-06-08'
     - user_id: VictorVAlbert

--- a/codes/classical/spherical/spherical.yml
+++ b/codes/classical/spherical/spherical.yml
@@ -60,7 +60,10 @@ protection: |
   Other bounds on spherical codes include the Fejes Toth bound \cite{manual:{L. Fejes Toth, Uber die Abschatzung des kiirzesten Abstandes zweier Punkte eines auf einer Kugelflache liegenden Punktsystemes, Jber. Deut. Math. Verein., 53, pp. 66-68, 1943}}, the Wyner bound \cite{doi:10.1002/j.1538-7305.1965.tb04170.x} and the apple-picking bound \cite{doi:10.1109/TIT.1987.1057277}.
 
 features:
-  rate: 'The Kabatiansky-Levenshtein bound \cite{preset:KLbounds}\cite[Ch. 9]{doi:10.1007/978-1-4757-6568-7} is the best known upper bound on the rate of a spherical code with fixed Euclidean distance.'
+  rate: |
+    The Kabatiansky-Levenshtein bound \cite{preset:KLbounds}\cite[Ch. 9]{doi:10.1007/978-1-4757-6568-7} is a classical upper bound on the rate of a spherical code with fixed Euclidean distance.
+    For every fixed maximum inner product \(0<s<1\), a hierarchy of two-point linear-programming certificates gives asymptotic upper bounds on the rate of unrestricted spherical codes that strictly improve the optimized Kabatiansky-Levenshtein exponent, including its spherical-cap optimization \cite[Thm. 1.2 and Cor. 1.3]{manual:{OpenAI, “Improved Bounds for Binary and Spherical Codes”, Chapter 2 in \emph{Ten Advances in Mathematics and Theoretical Computer Science} (updated August 6, 2026), \href{https://cdn.openai.com/pdf/ten-proofs-oai.pdf}{URL}}}.
+    These are converse bounds on code size; they do not supply code constructions, encoders, or decoders.
 
 notes:
   - 'See \cite{preset:EricZin,preset:Sloane04} for more details and tables of optimal codes.'
@@ -79,6 +82,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: DevanshSehgal
+      date: '2026-08-07'
     - user_id: VictorVAlbert
       date: '2026-06-08'
     - user_id: VictorVAlbert

--- a/users/users_db.yml
+++ b/users/users_db.yml
@@ -34,6 +34,10 @@
 
 #
 
+- user_id: DevanshSehgal
+  name: 'Devansh Sehgal'
+  githubusername: Devansh-ops
+
 - user_id: TomaszAndrzejewski
   name: 'Tomasz Andrzejewski'
   githubusername: TomaszAnd


### PR DESCRIPTION
## Modified Codes

**Binary code**:

- Document the August 2026 two-point LP converse bound that strictly improves the optimized MRRW bound for every fixed \(0<\delta<1/2\).
- Cite Chapter 2, Theorem 1.1 of *Ten Advances in Mathematics and Theoretical Computer Science*.
- Clarify that the result does not provide code constructions, encoders, or decoders.

**Spherical code**:

- Replace stale “best known” wording for the Kabatiansky–Levenshtein bound.
- Document the hierarchy that strictly improves the optimized KL exponent, including spherical-cap optimization, for every fixed \(0<s<1\).
- Cite Chapter 2, Theorem 1.2 and Corollary 1.3.
- Clarify that the result is a converse rather than a construction or coding algorithm.

## Checklist

- [x] Included primary-source citations.
- [x] No new cross-links to other Zoo codes are required.
- [x] Added both entry changelogs and the contributor record.

## Validation

- YAML parsing and contributor/changelog linkage
- Citation, first-paragraph, block-scalar, and spelling linters
- All repository relation checks across 1,116 entries
- Official schema, object, reference, and FLM compilation for the full corpus

The optional local full-site path was limited by pinned `sharp@0.30.7` under Node 24; upstream's Node 22 draft-preview workflow remains the authoritative site-build check.
