### PR TITLE
Update stab_15_1_3.yml

### DIFF
--- a/codes/quantum/qubits/small_distance/small/15/stab_15_1_3.yml
+++ b/codes/quantum/qubits/small_distance/small/15/stab_15_1_3.yml
@@ -17,7 +17,7 @@ alternative_names:
 
 description: |
   A \([[15,1,3]]\) quantum Reed-Muller code that is most easily thought of as a tetrahedral 3D color code.
-  It can be constructed as a CSS code from the \([15,5,8]\) punctured Reed-Muller code and its even subcode, which explains its transversal \(T^\dagger\) gate \cite{preset:GottesmanBook}.
+  It can be constructed as a CSS code from the \([15,5,7]\) punctured Reed-Muller code and its even subcode, which explains its transversal \(T^\dagger\) gate \cite{preset:GottesmanBook}.
 
   This code contains 15 qubits, represented by four vertices, four face centers, six edge centers, and one body center.
   The tetrahedron is cellulated into four identical polyhedron cells by connecting the body center to all four face centers, where each face center is then connected by three adjacent edge centers.
@@ -106,6 +106,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: theow521
+      date: '2026-08-29'
     - user_id: VictorVAlbert
       date: '2026-06-08'
     - user_id: remmyzen


### PR DESCRIPTION
The parameters of the punctured Reed-Muller code on line 20 were previously [15,5,8]. This is a typo. The [16,5,8] RM(1,4) code when punctured becomes a [15,5,7]  RM*(1,4) code (see MacWilliams and Sloane Chapter 13).

[Please provide a brief description of your suggested changes here. If you are
simply providing new codes / modifying existing ones, simply describe your
changes below. Don't forget to remove this text.]

## New Codes:

- N/A

## Modified Codes:

**QRM Code**:
- Corrected params of the classical base code.

## Checklist:

I remembered to:

- [✅ ] Include relevant citations I could think of (with `\cite{...}`)

- [ ✅] Create links to the other referenced codes (with
      `\hyperref[code:...]{...}`)

- [ ✅] Update the relevant meta changelog fields with my user_id (see
      `users/users_db.yml`; add yourself in the PR if you aren't there already)

