### PR TITLE
Add self-orthogonal CSS(RM(r,m),RM(r,m)) family and its distance to quantum_reed_muller entry

### DIFF
--- a/codes/quantum/qubits/stabilizer/rm/quantum_reed_muller.yml
+++ b/codes/quantum/qubits/stabilizer/rm/quantum_reed_muller.yml
@@ -36,9 +36,6 @@ features:
 
   rate: 'Dimension is \(k = 2^r - {r \choose t} + 2 \sum_{i=0}^{t-1} {r \choose i}\). CSS codes formed from RM codes achieve channel capacity on erasure channels \cite{doi:10.1109/ISIT.2016.7541599}.'
 
-  distance:
-    - 'CSS codes formed from a single RM code, CSS\((\text{RM}(r,m),\text{RM}(r,m))\) with \(2r < m-1\), have distance \(d = 2^{r+1}\) \cite[Ch. 13]{preset:MacSlo}.'
-    - 'The distance of this family admits a certificate that can be checked without enumerating the exponentially many error patterns: for \(r \geq 1\), column-distinctness of the RM check matrix rules out weight-2 logicals; the RM minimum-weight theorem \cite[Ch. 13]{preset:MacSlo} rules out weights \(3,\ldots,2^{r+1}-1\); and indicator vectors of affine \((r+1)\)-flats are weight-\(2^{r+1}\) vectors in \(\text{RM}(m-r-1,m)\setminus\text{RM}(r,m)\), saturating the bound.'
 
   fault_tolerance:
     - 'Gate switching protocol for universal computation \cite{arxiv:1403.2734}.'

--- a/codes/quantum/qubits/stabilizer/rm/quantum_reed_muller.yml
+++ b/codes/quantum/qubits/stabilizer/rm/quantum_reed_muller.yml
@@ -36,7 +36,6 @@ features:
 
   rate: 'Dimension is \(k = 2^r - {r \choose t} + 2 \sum_{i=0}^{t-1} {r \choose i}\). CSS codes formed from RM codes achieve channel capacity on erasure channels \cite{doi:10.1109/ISIT.2016.7541599}.'
 
-
   fault_tolerance:
     - 'Gate switching protocol for universal computation \cite{arxiv:1403.2734}.'
     - 'Fault-tolerant universal computation can be achieved via \hyperref[topic:code-switching]{code switching} between the \([[127,1,15]]\) self-dual doubly even punctured quantum RM code and the \([[127,1,7]]\) triply even punctured quantum RM code \cite{arxiv:2410.23263}.'

--- a/codes/quantum/qubits/stabilizer/rm/quantum_reed_muller.yml
+++ b/codes/quantum/qubits/stabilizer/rm/quantum_reed_muller.yml
@@ -20,6 +20,9 @@ description: |
 
   Non-CSS codes can be derived from such codes by modifying the \(X\)-type stabilizers \cite{arxiv:quant-ph/9608026}.
 
+  CSS codes formed from a single RM code are also possible: CSS\((\text{RM}(r,m), \text{RM}(r,m))\), valid whenever \(2r < m-1\) (so that \(\text{RM}(r,m) \subset \text{RM}(r,m)^{\perp} = \text{RM}(m-r-1,m)\)), has parameters \([[2^m, 2^m - 2\sum_{j=0}^{r} {m \choose j}, 2^{r+1}]]\).
+  Its distance \(2^{r+1}\) follows from the RM minimum-weight theorem \cite[Ch. 13]{preset:MacSlo}: \(X\)-type logicals are cosets of \(C \setminus C^{\perp}\), whose minimum weight is that of \(\text{RM}(m-r-1,m)\), i.e., \(2^{m-(m-r-1)} = 2^{r+1}\); \(Z\)-type logicals follow by symmetry.
+
 protection: 'Detects errors on \(d-1\) qubits, corrects errors on \(\left\lfloor (d-1)/2 \right\rfloor\) qubits.'
 
 features:
@@ -32,6 +35,10 @@ features:
   magic_scaling_exponent: 'The family constructed out of shortened RM codes with parameters \([[\sum_{i=w+1}^m \binom{m}{i}, \sum_{i=0}^{w} \binom{m}{i}, \sum_{i=w+1}^{r+1} \binom{r+1}{i}]]\) for integers \(m > 2r\) and \(r > w \geq 0\) yields protocols with an exponent of \(\gamma < 0.678\), with the fewest-resource protocol with \(\gamma < 1\) requiring a code with parameters \(\{r,w,m\} = \{19,14,3r+1\}\) such that \(n \approx 2^{58}\) qubits \cite[Corr. 1]{arxiv:1709.03543}. This refutes a conjecture that no protocol could achieve \(\gamma < 1\) \cite{arxiv:1209.2426}.'
 
   rate: 'Dimension is \(k = 2^r - {r \choose t} + 2 \sum_{i=0}^{t-1} {r \choose i}\). CSS codes formed from RM codes achieve channel capacity on erasure channels \cite{doi:10.1109/ISIT.2016.7541599}.'
+
+  distance:
+    - 'CSS codes formed from a single RM code, CSS\((\text{RM}(r,m),\text{RM}(r,m))\) with \(2r < m-1\), have distance \(d = 2^{r+1}\) \cite[Ch. 13]{preset:MacSlo}.'
+    - 'The distance of this family admits a certificate that can be checked without enumerating the exponentially many error patterns: for \(r \geq 1\), column-distinctness of the RM check matrix rules out weight-2 logicals; the RM minimum-weight theorem \cite[Ch. 13]{preset:MacSlo} rules out weights \(3,\ldots,2^{r+1}-1\); and indicator vectors of affine \((r+1)\)-flats are weight-\(2^{r+1}\) vectors in \(\text{RM}(m-r-1,m)\setminus\text{RM}(r,m)\), saturating the bound.'
 
   fault_tolerance:
     - 'Gate switching protocol for universal computation \cite{arxiv:1403.2734}.'
@@ -62,6 +69,8 @@ relations:
 _meta:
   # Change log - most recent first
   changelog:
+    - user_id: sdoygb
+      date: '2026-08-13'
     - user_id: VictorVAlbert
       date: '2026-06-08'
     - user_id: VictorVAlbert

--- a/users/users_db.yml
+++ b/users/users_db.yml
@@ -716,3 +716,8 @@
   githubusername: LeonidPryadko
   pageurl: "https://faculty.ucr.edu/~leonid/"
   avatarurl: "builtinavatar:LeonidPryadko"
+
+- user_id: sdoygb
+  name: 'Ouyang Guobin'
+  githubusername: sdoygb
+


### PR DESCRIPTION
> **Re-submitted.** This supersedes #381, which GitHub permanently closed when its source fork was deleted — a pull request cannot be reopened once its head repository is gone.
> Branch and commit are identical to the original.

This PR adds to the quantum Reed-Muller entry:

1. The CSS(RM(r,m), RM(r,m)) family (self-orthogonal for 2r < m-1), with explicit parameters [[2^m, 2^m - 2*Sum_{j<=r} C(m,j), 2^(r+1)]] and the distance derivation from the RM minimum-weight theorem (MacWilliams-Sloane, Ch. 13).
2. A `distance` feature noting that the distance of this family admits a certificate checkable without enumerating the exponentially many error patterns: for r >= 1, column-distinctness of the RM check matrix (no weight-2 logicals), the RM minimum-weight theorem (no intermediate weights), and affine (r+1)-flat indicators as weight-2^(r+1) vectors in RM(m-r-1,m) \ RM(r,m) saturating the bound.

## Checklist

- [x] `_meta.changelog` updated (user_id: sdoygb, 2026-08-13)
- [x] User entry added in `users/users_db.yml`
- [x] YAML syntax validated locally
- [x] Previewed via https://errorcorrectionzoo.org/gitpreview

## Verification note

Family parameters and the certificate were verified numerically for members
[[32,20,4]], [[64,50,4]], [[64,20,8]], [[128,70,8]], [[256,70,16]], [[512,252,16]], [[1024,252,32]]:
weight-4 layer counts (1240 and 10416) match the affine-flat counting formula exactly, and
[[64,20,8]] passed a full brute-force check of all 7.05e8 error sets of weight 1..7 with zero undetected.
